### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[jstrachan/nodey425](https://github.com/jstrachan/nodey425.git) |  | []() | 
+[jstrachan/nodey426](https://github.com/jstrachan/nodey426.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[jstrachan/nodey427](https://github.com/jstrachan/nodey427.git) |  | []() | 
+[jstrachan/nodey429](https://github.com/jstrachan/nodey429.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[jstrachan/nodey426](https://github.com/jstrachan/nodey426.git) |  | []() | 
+[jstrachan/nodey427](https://github.com/jstrachan/nodey427.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[jstrachan/nodey429](https://github.com/jstrachan/nodey429.git) |  | []() | 
+[jstrachan/nodey430](https://github.com/jstrachan/nodey430.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[jstrachan/nodey425](https://github.com/jstrachan/nodey425.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: jstrachan
-  repo: nodey429
-  url: https://github.com/jstrachan/nodey429.git
+  repo: nodey430
+  url: https://github.com/jstrachan/nodey430.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: jstrachan
+  repo: nodey425
+  url: https://github.com/jstrachan/nodey425.git
+  version: ""
+  versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: jstrachan
-  repo: nodey425
-  url: https://github.com/jstrachan/nodey425.git
+  repo: nodey426
+  url: https://github.com/jstrachan/nodey426.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: jstrachan
-  repo: nodey427
-  url: https://github.com/jstrachan/nodey427.git
+  repo: nodey429
+  url: https://github.com/jstrachan/nodey429.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: jstrachan
-  repo: nodey426
-  url: https://github.com/jstrachan/nodey426.git
+  repo: nodey427
+  url: https://github.com/jstrachan/nodey427.git
   version: ""
   versionURL: ""

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -1,2 +1,2 @@
-buildPackGitURL: https://github.com/jenkins-x-labs/jenkins-x-kubernetes.git
 buildPack: environment-helmfile
+buildPackGitURL: https://github.com/jenkins-x-labs/jenkins-x-kubernetes.git

--- a/jx-apps.yml
+++ b/jx-apps.yml
@@ -6,6 +6,6 @@ apps:
 - name: jenkins-x/tekton
 #- name: jenkins-x/chartmuseum
 - name: jenkins-x/bucketrepo
-  version: 0.1.34
+  version: 0.1.35
 - name: repositories
   repository: ".."

--- a/jx-apps.yml
+++ b/jx-apps.yml
@@ -6,6 +6,6 @@ apps:
 - name: jenkins-x/tekton
 #- name: jenkins-x/chartmuseum
 - name: jenkins-x/bucketrepo
-  version: 0.1.35
+  version: 0.1.34
 - name: repositories
   repository: ".."

--- a/jx-apps.yml
+++ b/jx-apps.yml
@@ -6,6 +6,6 @@ apps:
 - name: jenkins-x/tekton
 #- name: jenkins-x/chartmuseum
 - name: jenkins-x/bucketrepo
-  version: 0.1.32
+  version: 0.1.34
 - name: repositories
   repository: ".."

--- a/jx-requirements.yml
+++ b/jx-requirements.yml
@@ -3,6 +3,7 @@ autoUpdate:
   schedule: ""
 bootConfigURL: https://github.com/jenkins-x/jenkins-x-boot-helmfile-config
 cluster:
+  chartRepository: http://bucketrepo/bucketrepo/charts/
   clusterName: kind
   devEnvApprovers:
   - jstrachan

--- a/jx-requirements.yml
+++ b/jx-requirements.yml
@@ -1,7 +1,6 @@
 autoUpdate:
   enabled: false
   schedule: ""
-bootConfigURL: https://github.com/jenkins-x/jenkins-x-boot-helmfile-config
 cluster:
   chartRepository: http://bucketrepo/bucketrepo/charts/
   clusterName: kind
@@ -80,6 +79,6 @@ velero:
   schedule: ""
   ttl: ""
 versionStream:
-  ref: v1.0.385
-  url: https://github.com/jenkins-x/jenkins-x-versions.git
+  ref: bump-regex-version-9c317c06-63b0-11ea-95f0-acde48001122
+  url: https://github.com/jstrachan/jenkins-x-versions.git
 webhook: lighthouse

--- a/jx-requirements.yml
+++ b/jx-requirements.yml
@@ -59,7 +59,7 @@ ingress:
     enabled: false
     production: false
 kaniko: true
-repository: nexus
+repository: bucketrepo
 secretStorage: local
 storage:
   backup:

--- a/jx-requirements.yml
+++ b/jx-requirements.yml
@@ -17,9 +17,10 @@ cluster:
   registry: 192.168.1.64:5000
 environments:
 - ingress:
-    domain: ""
+    domain: 192.168.1.64.nip.io
     externalDNS: false
-    namespaceSubDomain: ""
+    ignoreLoadBalancer: true
+    namespaceSubDomain: -jx.
     tls:
       email: ""
       enabled: false

--- a/repositories/templates/jstrachan-nodey425-sr.yaml
+++ b/repositories/templates/jstrachan-nodey425-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: jstrachan
+    provider: github
+    repository: nodey425
+  name: jstrachan-nodey425
+spec:
+  description: Imported application for jstrachan/nodey425
+  httpCloneURL: https://github.com/jstrachan/nodey425.git
+  org: jstrachan
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: nodey425
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/jstrachan/nodey425.git

--- a/repositories/templates/jstrachan-nodey426-sr.yaml
+++ b/repositories/templates/jstrachan-nodey426-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: jstrachan
+    provider: github
+    repository: nodey426
+  name: jstrachan-nodey426
+spec:
+  description: Imported application for jstrachan/nodey426
+  httpCloneURL: https://github.com/jstrachan/nodey426.git
+  org: jstrachan
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: nodey426
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/jstrachan/nodey426.git

--- a/repositories/templates/jstrachan-nodey427-sr.yaml
+++ b/repositories/templates/jstrachan-nodey427-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: jstrachan
+    provider: github
+    repository: nodey427
+  name: jstrachan-nodey427
+spec:
+  description: Imported application for jstrachan/nodey427
+  httpCloneURL: https://github.com/jstrachan/nodey427.git
+  org: jstrachan
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: nodey427
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/jstrachan/nodey427.git

--- a/repositories/templates/jstrachan-nodey429-sr.yaml
+++ b/repositories/templates/jstrachan-nodey429-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: jstrachan
+    provider: github
+    repository: nodey429
+  name: jstrachan-nodey429
+spec:
+  description: Imported application for jstrachan/nodey429
+  httpCloneURL: https://github.com/jstrachan/nodey429.git
+  org: jstrachan
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: nodey429
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/jstrachan/nodey429.git

--- a/repositories/templates/jstrachan-nodey430-sr.yaml
+++ b/repositories/templates/jstrachan-nodey430-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: jstrachan
+    provider: github
+    repository: nodey430
+  name: jstrachan-nodey430
+spec:
+  description: Imported application for jstrachan/nodey430
+  httpCloneURL: https://github.com/jstrachan/nodey430.git
+  org: jstrachan
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: nodey430
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/jstrachan/nodey430.git


### PR DESCRIPTION
Update [jstrachan/nodey430](https://github.com/jstrachan/nodey430.git) 

Command run was `jxl project import --url https://github.com/jstrachan/nodey430 --no-pack`
<hr />

Update [jstrachan/nodey430](https://github.com/jstrachan/nodey430.git) 

Command run was `jxl project import --no-pack`
<hr />

Update [jstrachan/nodey430](https://github.com/jstrachan/nodey430.git) 

Command run was `jxl project quickstart`
<hr />

Update [jstrachan/nodey429](https://github.com/jstrachan/nodey429.git) 

Command run was `/workspace/go/src/github.com/jenkins-x-labs/jwizard/build/jwizard quickstart`
<hr />

Update [jstrachan/nodey427](https://github.com/jstrachan/nodey427.git) 

Command run was `jwizard quickstart`
<hr />

Update [jstrachan/nodey426](https://github.com/jstrachan/nodey426.git) 

Command run was `jxl project quickstart`
<hr />

Update [jstrachan/nodey425](https://github.com/jstrachan/nodey425.git) 

Command run was `/workspace/go/src/github.com/jenkins-x-labs/jwizard/build/jwizard quickstart`